### PR TITLE
Catering for fetches of non existent resources

### DIFF
--- a/helpers/prometheus.py
+++ b/helpers/prometheus.py
@@ -227,6 +227,7 @@ class SentryCollector(object):
                         proj=project.get("slug"), env=env
                     )
                 )
+
                 project_issues_1h = project_issues.get(env).get("1h")
                 project_issues_24h = project_issues.get(env).get("24h")
                 project_issues_14d = project_issues.get(env).get("14d")

--- a/libs/sentry.py
+++ b/libs/sentry.py
@@ -170,7 +170,8 @@ class SentryAPI(object):
 
         for stat_name, values in stats.items():
             for stat in values:
-                events += stat[1]
+                if type(stat) != str:
+                    events += stat[1]
             project_events[stat_name] = events
 
         return project_events
@@ -197,7 +198,8 @@ class SentryAPI(object):
                 org=org_slug, proj_slug=project.get("slug")
             ),
         )
-
+        if resp.status_code == 404:
+            return []
         environments = [env.get("name") for env in resp.json()]
         return environments
 
@@ -233,7 +235,10 @@ class SentryAPI(object):
             issues = {}
             issues_url = issues_url + "&environment={env}".format(env=environment)
             resp = self.__get(issues_url)
-            issues[environment] = resp.json()
+            if resp.status_code == 404:
+                issues[environment] = []
+            else:
+                issues[environment] = resp.json()  
             return issues
         else:
             resp = self.__get(issues_url)


### PR DESCRIPTION
## Description

Perhaps related to how the Sentry instance is set up, but when running release v0.1 I had quite a few errors related to there being certain data elements that couldn't be fetched giving "requested resources does not exist". This mainly occurred when trying to get project issue time frames, and an example of the error is shown here:
```
  File "/app/libs/sentry.py", line 201, in <listcomp>
    environments = [env.get("name") for env in resp.json()]
AttributeError: 'str' object has no attribute 'get'

{'detail': 'The requested resource does not exist'}
```
Sometimes data is returned similar to the above example, and so I have added in type checks for project_issues _xh and events.
Similarly, sometimes the get environments function would return error 404 (perhaps because some environments exist in some projects but not in other?). If the request returns status code 404 it will just return an empty list.

None of these changes should affect functionality as they are just catching weird edge cases, and if anything make the code a bit more robust. The package works (both with & without dockerisation) for me. I didn't create an issue as this is rather minor change in the grand scheme of things - happy to create one and/or make any necessary changes!

## Checklist

- [Unnecessary ] All tests are passing
- [Unnecessary ] New tests were created to address changes in pr (and tests are passing)
- [ Unnecessary] Updated README and/or documentation, if necessary
