### PR TITLE
Handle Sentry HTTP errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,20 @@ export SENTRY_ISSUES_14D=False
 ```
 As with `SENTRY_AUTH_TOKEN`, all of these variables can be passed in through the `docker run -e VAR_NAME=<>` command or via the `.env` file if using Docker Compose.
 
+### Retries to get around limits
+
+The Sentry API limits the rate of requests to 3 per second, so the exporter retries on an HTTP exception.
+
+You can tweak your settings with environment variables, though default settings should work:
+
+|  Environment variable    | Value type | Default value |                         Purpose                         |
+|:------------------------:|:----------:|:-------------:|:-------------------------------------------------------:|
+| `SENTRY_RETRY_TRIES`     | Integer    | 3             | How many retries should be made in case of an exception |
+| `SENTRY_RETRY_DELAY`     | Float      | 1             | How many seconds to wait between retries                |
+| `SENTRY_RETRY_MAX_DELAY` | Float      | 10            | Max delay to wait between retries                       |
+| `SENTRY_RETRY_BACKOFF`   | Float      | 2             | Multiplier applied to delay between attempts            |
+| `SENTRY_RETRY_JITTER`    | Float      | 0.5           | Extra seconds added to delay between attempts           |
+
 ## Samples
 
 **Grafana Dashboard**
@@ -122,7 +136,7 @@ scrape_configs:
 
 Contributions, issues and feature requests are welcome!
 
-- Feel free to check [issues page](https://github.com/italux/sentry-prometheus-exporter/issues). 
+- Feel free to check [issues page](https://github.com/italux/sentry-prometheus-exporter/issues).
 
 
 ## 📝 License

--- a/README.md
+++ b/README.md
@@ -84,20 +84,6 @@ export SENTRY_ISSUES_14D=False
 ```
 As with `SENTRY_AUTH_TOKEN`, all of these variables can be passed in through the `docker run -e VAR_NAME=<>` command or via the `.env` file if using Docker Compose.
 
-### Retries to get around limits
-
-The Sentry API limits the rate of requests to 3 per second, so the exporter retries on an HTTP exception.
-
-You can tweak your settings with environment variables, though default settings should work:
-
-|  Environment variable    | Value type | Default value |                         Purpose                         |
-|:------------------------:|:----------:|:-------------:|:-------------------------------------------------------:|
-| `SENTRY_RETRY_TRIES`     | Integer    | 3             | How many retries should be made in case of an exception |
-| `SENTRY_RETRY_DELAY`     | Float      | 1             | How many seconds to wait between retries                |
-| `SENTRY_RETRY_MAX_DELAY` | Float      | 10            | Max delay to wait between retries                       |
-| `SENTRY_RETRY_BACKOFF`   | Float      | 2             | Multiplier applied to delay between attempts            |
-| `SENTRY_RETRY_JITTER`    | Float      | 0.5           | Extra seconds added to delay between attempts           |
-
 ## Samples
 
 **Grafana Dashboard**
@@ -118,6 +104,20 @@ scrape_configs:
 
 ### Limitations
 - **Performance**: The exporter is serial, if your organization has a high number of issues & events you may experience `Context Deadline Exceeded` error during a Prometheus scrape
+
+### Sentry API retry calls
+
+The Sentry API limits the rate of requests to 3 per second, so the exporter retries on an HTTP exception.
+
+You can tweak retry settings with environment variables, though default settings should work:
+
+|  Environment variable    | Value type | Default value |                         Purpose                         |
+|:------------------------:|:----------:|:-------------:|:-------------------------------------------------------:|
+| `SENTRY_RETRY_TRIES`     | Integer    | 3             | How many retries should be made in case of an exception |
+| `SENTRY_RETRY_DELAY`     | Float      | 1             | How many seconds to wait between retries                |
+| `SENTRY_RETRY_MAX_DELAY` | Float      | 10            | Max delay to wait between retries                       |
+| `SENTRY_RETRY_BACKOFF`   | Float      | 2             | Multiplier applied to delay between attempts            |
+| `SENTRY_RETRY_JITTER`    | Float      | 0.5           | Extra seconds added to delay between attempts           |
 
 ### Recomendations & Tips
 - Use `scrape_interval: 5m` minimum.

--- a/libs/sentry.py
+++ b/libs/sentry.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from os import getenv
+from retry import retry
 
 import requests
 
@@ -27,9 +27,12 @@ class SentryAPI(object):
         self.__token = auth_token
         self.__session = requests.Session()
 
+    @retry(requests.exceptions.HTTPError, tries=2, delay=1)
     def __get(self, url):
         HEADERS = {"Authorization": "Bearer " + self.__token}
-        return self.__session.get(self.base_url + url, headers=HEADERS)
+        response = self.__session.get(self.base_url + url, headers=HEADERS)
+        response.raise_for_status()
+        return response
 
     def __post(self, url):
         raise NotImplementedError

--- a/libs/sentry.py
+++ b/libs/sentry.py
@@ -1,8 +1,16 @@
 from datetime import datetime
-from retry import retry
+from os import getenv
 
+from retry import retry
 import requests
 
+retry_settings = {
+    'tries': int(getenv('SENTRY_RETRY_TRIES', '3')),
+    'delay': float(getenv('SENTRY_RETRY_DELAY', '1')),
+    'max_delay': float(getenv('SENTRY_RETRY_MAX_DELAY', '10')),
+    'backoff': float(getenv('SENTRY_RETRY_BACKOFF', '2')),
+    'jitter': float(getenv('SENTRY_RETRY_JITTER', '0.5'))
+}
 
 class SentryAPI(object):
     """A simple :class:`SentryAPI <SentryAPI>` to interact with Sentry's Web API.
@@ -27,7 +35,7 @@ class SentryAPI(object):
         self.__token = auth_token
         self.__session = requests.Session()
 
-    @retry(requests.exceptions.HTTPError, tries=2, delay=1)
+    @retry(requests.exceptions.HTTPError, **retry_settings)
     def __get(self, url):
         HEADERS = {"Authorization": "Bearer " + self.__token}
         response = self.__session.get(self.base_url + url, headers=HEADERS)

--- a/libs/sentry.py
+++ b/libs/sentry.py
@@ -5,12 +5,13 @@ from retry import retry
 import requests
 
 retry_settings = {
-    'tries': int(getenv('SENTRY_RETRY_TRIES', '3')),
-    'delay': float(getenv('SENTRY_RETRY_DELAY', '1')),
-    'max_delay': float(getenv('SENTRY_RETRY_MAX_DELAY', '10')),
-    'backoff': float(getenv('SENTRY_RETRY_BACKOFF', '2')),
-    'jitter': float(getenv('SENTRY_RETRY_JITTER', '0.5'))
+    "tries": int(getenv("SENTRY_RETRY_TRIES", "3")),
+    "delay": float(getenv("SENTRY_RETRY_DELAY", "1")),
+    "max_delay": float(getenv("SENTRY_RETRY_MAX_DELAY", "10")),
+    "backoff": float(getenv("SENTRY_RETRY_BACKOFF", "2")),
+    "jitter": float(getenv("SENTRY_RETRY_JITTER", "0.5")),
 }
+
 
 class SentryAPI(object):
     """A simple :class:`SentryAPI <SentryAPI>` to interact with Sentry's Web API.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Flask==1.0.2
+Flask==2.0.1
 prometheus-client==0.11.0
 requests==2.26.0
 retry==0.9.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Flask==2.0.1
+Flask==1.0.2
 prometheus-client==0.11.0
 requests==2.26.0
 retry==0.9.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 Flask==1.0.2
 prometheus-client==0.9.0
 requests==2.25.1
+retry==0.9.2


### PR DESCRIPTION
## Description

This adds a retry module to retry requests to close #21 

PS: I removed `from os import get_env` is because `get_env` wasn't used anywhere

### Before

<img width="1300" alt="image" src="https://user-images.githubusercontent.com/2182934/132732771-a42eede4-18e4-4084-b544-c7c6de6dbdaf.png">
<img width="1313" alt="image" src="https://user-images.githubusercontent.com/2182934/132732789-d9a60388-f6a7-4fbb-96e9-10436a63d597.png">

### After

<img width="937" alt="image" src="https://user-images.githubusercontent.com/2182934/132733028-8fc5eb90-9dc9-439b-8386-9cbb28d1a0e3.png">
<img width="2237" alt="image" src="https://user-images.githubusercontent.com/2182934/132733103-b0232917-a5ee-443d-adc4-7755f474534c.png">

## Checklist

- [X] All tests are passing
- [X] New tests were created to address changes in pr (and tests are passing)
- [X] Updated README and/or documentation, if necessary

Thanks for contributing!
