### PR TITLE
Add rate limit for requests to the Sentry API

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,19 @@ export SENTRY_ISSUES_14D=False
 ```
 As with `SENTRY_AUTH_TOKEN`, all of these variables can be passed in through the `docker run -e VAR_NAME=<>` command or via the `.env` file if using Docker Compose.
 
+### Rate limit
+
+The Sentry API limits the rate of requests to 3 per second, so by default the exporter makes 2 requests per second to comply with this.
+
+You can tweak your settings to increase or decrease the request rate of the exporter using the following environment variables:
+
+```sh
+export SENTRY_RATE_LIMIT CALLS=2
+export SENTRY_RATE_LIMIT_PERIOD=1
+```
+
+Calls being the number of requests and period the timeframe, in seconds. If you don't set the variables, it defaults to a max. 2 requests per second.
+
 ## Samples
 
 **Grafana Dashboard**

--- a/libs/sentry.py
+++ b/libs/sentry.py
@@ -4,6 +4,8 @@ from ratelimit import limits, sleep_and_retry
 
 import requests
 
+rate_limit_calls = getenv("SENTRY_RATE_LIMIT_CALLS") or 2
+rate_limit_period = getenv("SENTRY_RATE_LIMIT_PERIOD") or 1
 
 class SentryAPI(object):
     """A simple :class:`SentryAPI <SentryAPI>` to interact with Sentry's Web API.
@@ -31,7 +33,7 @@ class SentryAPI(object):
 
     # The rate limit for the sentry API is 3 requests per second according to the response, but setting the calls to 3 won't work. Running it with 2 calls per second is slow, but works every time.
     @sleep_and_retry
-    @limits(calls=2, period=1)
+    @limits(calls=int(rate_limit_calls), period=int(rate_limit_period))
     def __get(self, url):
         HEADERS = {"Authorization": "Bearer " + self.__token}
         return self.__session.get(self.base_url + url, headers=HEADERS)

--- a/libs/sentry.py
+++ b/libs/sentry.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 from os import getenv
+from ratelimit import limits, sleep_and_retry
 
 import requests
 
@@ -27,6 +28,10 @@ class SentryAPI(object):
         self.__token = auth_token
         self.__session = requests.Session()
 
+
+    # The rate limit for the sentry API is 3 requests per second according to the response, but setting the calls to 3 won't work. Running it with 2 calls per second is slow, but works every time.
+    @sleep_and_retry
+    @limits(calls=2, period=1)
     def __get(self, url):
         HEADERS = {"Authorization": "Bearer " + self.__token}
         return self.__session.get(self.base_url + url, headers=HEADERS)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,13 @@
+certifi==2021.5.30
+chardet==4.0.0
+click==8.0.1
 Flask==1.0.2
+idna==2.10
+itsdangerous==2.0.1
+Jinja2==3.0.1
+MarkupSafe==2.0.1
 prometheus-client==0.9.0
+ratelimit==2.2.1
 requests==2.25.1
+urllib3==1.26.6
+Werkzeug==2.0.1


### PR DESCRIPTION
## Description

When the sentry exporter is run as-is, it can hit the Sentry API rate limit depending on the number of events, issues, and projects.

When this happens, the server returns an obscure error, and the logs return something like this:

```
2021-09-17 12:31:05,844 - 18314 - ERROR - flask.app - Exception on /metrics/ [GET]
Traceback (most recent call last):
  File "/Users/gonzalo/.pyenv/versions/qqtron/lib/python3.8/site-packages/flask/app.py", line 2292, in wsgi_app
    response = self.full_dispatch_request()
  File "/Users/gonzalo/.pyenv/versions/qqtron/lib/python3.8/site-packages/flask/app.py", line 1815, in full_dispatch_request
    rv = self.handle_user_exception(e)
  File "/Users/gonzalo/.pyenv/versions/qqtron/lib/python3.8/site-packages/flask/app.py", line 1718, in handle_user_exception
    reraise(exc_type, exc_value, tb)
  File "/Users/gonzalo/.pyenv/versions/qqtron/lib/python3.8/site-packages/flask/_compat.py", line 35, in reraise
    raise value
  File "/Users/gonzalo/.pyenv/versions/qqtron/lib/python3.8/site-packages/flask/app.py", line 1813, in full_dispatch_request
    rv = self.dispatch_request()
  File "/Users/gonzalo/.pyenv/versions/qqtron/lib/python3.8/site-packages/flask/app.py", line 1799, in dispatch_request
    return self.view_functions[rule.endpoint](**req.view_args)
  File "exporter.py", line 61, in sentry_exporter
    REGISTRY.register(SentryCollector(sentry, ORG_SLUG, get_metric_config(), PROJECTS_SLUG))
  File "/Users/gonzalo/.pyenv/versions/qqtron/lib/python3.8/site-packages/prometheus_client/registry.py", line 26, in register
    names = self._get_names(collector)
  File "/Users/gonzalo/.pyenv/versions/qqtron/lib/python3.8/site-packages/prometheus_client/registry.py", line 66, in _get_names
    for metric in desc_func():
  File "/Users/gonzalo/work/sentry-exporter/helpers/prometheus.py", line 265, in collect
    events_14d += int(issue.get("count") or 0)
AttributeError: 'str' object has no attribute 'get'
```

This happens _after_ everything is downloaded from Sentry when the exporter aggregates issues and finds the API returned a string instead of an integer.

If we inspect the JSON cache file, the problem happens when the rate limit is reached, to which the API responds with: 
```
{"detail": "You are attempting to use this endpoint too quickly. Limit is 3/1s"}
```

This PR limits the request rate to the Sentry API and ensures it will never make more than 2 requests per second to avoid hitting the 3req/s limit. It's configurable, and I've added two environment variables for configuration and some documentation in the README.

## Checklist

- [ ] All tests are passing
- [ ] New tests were created to address changes in pr (and tests are passing)
- [X] Updated README and/or documentation, if necessary

Thanks for contributing!
