### PR TITLE
fix(sentry): projects pagination

### DIFF
--- a/helpers/prometheus.py
+++ b/helpers/prometheus.py
@@ -125,7 +125,7 @@ class SentryCollector(object):
             log.info(
                 "metadata: no projects specified, loading from API".format(num_proj=len(projects))
             )
-            for project in self.__sentry_api.projects():
+            for project in self.__sentry_api.projects(self.sentry_org_slug):
                 projects.append(project)
                 projects_slug.append(project.get("slug"))
                 envs = self.__sentry_api.environments(self.org.get("slug"), project)

--- a/libs/sentry.py
+++ b/libs/sentry.py
@@ -93,14 +93,17 @@ class SentryAPI(object):
 
         return organization
 
-    def projects(self):
-        """Return a list of projects available to the authenticated session.
+    def projects(self, org_slug):
+        """Return a list of projects of the specified organization.
+
+        Args:
+            org_slug: A organization's slug string name.
 
         Returns:
             A list mapping with dictionary keys to the corresponding projects
         """
 
-        resp = self.__get("projects/")
+        resp = self.__get("organizations/{org}/projects/?all_projects=1".format(org=org_slug))
         projects = []
         for proj in resp.json():
             project = {}


### PR DESCRIPTION
## Description

Fixes #29

Not correctly managing project list pagination.

If the sentry organization has 300 projects only 100 random ones will be scraped.
This is due to the usage of the `https://sentry.io/api/0/projects/` endpoint, that seems to return the first 100 random projects.

The [API docs](https://docs.sentry.io/api/organizations/list-an-organizations-projects/) of the `https://sentry.io/api/0/organizations/{organization_slug}/projects/` refer the existence of a `cursor` query parameter to deal with pagination.
Also passing the `all_projects=1` query parameter appears to bypass pagination (returns all projects).

## Checklist

- [ ] All tests are passing
- [ ] New tests were created to address changes in pr (and tests are passing)
- [ ] Updated README and/or documentation, if necessary

Thanks for contributing!
