### PR TITLE
fix: First day of month wrong timestamp

### DIFF
--- a/libs/sentry.py
+++ b/libs/sentry.py
@@ -164,7 +164,12 @@ class SentryAPI(object):
             A dict([list])
         """
 
-        first_day_month = datetime.timestamp(datetime.today().replace(day=1))
+        first_day_month = datetime.timestamp(
+            datetime.combine(
+                datetime.today().replace(day=1),
+                datetime.min.time()
+            )
+        )
         today = datetime.timestamp(datetime.today())
         stat_names = ["received", "rejected", "blacklisted"]
         stats = {}

--- a/libs/sentry.py
+++ b/libs/sentry.py
@@ -165,10 +165,7 @@ class SentryAPI(object):
         """
 
         first_day_month = datetime.timestamp(
-            datetime.combine(
-                datetime.today().replace(day=1),
-                datetime.min.time()
-            )
+            datetime.combine(datetime.today().replace(day=1), datetime.min.time())
         )
         today = datetime.timestamp(datetime.today())
         stat_names = ["received", "rejected", "blacklisted"]


### PR DESCRIPTION
## Description
Fix issue #41 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved the calculation of the first day of the month to ensure accurate timestamp generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->