### PR TITLE
Bug fix: update `utils.py` to handle encountered `json.decoder.JSONDecodeError:` bug

### DIFF
--- a/helpers/utils.py
+++ b/helpers/utils.py
@@ -28,7 +28,10 @@ def write_cache(filename, data, expire_timestamp=None):
 def get_cached(filename):
     """Validate if we already have a local token stored, if doesn't initiate the oauth workflow"""
     if os.path.isfile(filename):
-        cache = json.load(open(filename, "r"))
+        try:
+            cache = json.load(open(filename, "r"))
+        except json.decoder.JSONDecodeError:
+            return False
         if cache.get("expire_at") <= datetime.timestamp(datetime.now()):
             log.debug("cache: expired data, removing cache file: {file}".format(file=filename))
             return False

--- a/helpers/utils.py
+++ b/helpers/utils.py
@@ -5,6 +5,7 @@ from datetime import datetime
 from flask_healthz import HealthError
 from libs.sentry import SentryAPI
 from os import getenv
+import os
 
 # TODO - Move these settings to use Flask Ccnfiguration Handling
 # https://flask.palletsprojects.com/en/2.0.x/config/
@@ -31,6 +32,7 @@ def get_cached(filename):
         try:
             cache = json.load(open(filename, "r"))
         except json.decoder.JSONDecodeError:
+            os.remove(filename)
             return False
         if cache.get("expire_at") <= datetime.timestamp(datetime.now()):
             log.debug("cache: expired data, removing cache file: {file}".format(file=filename))


### PR DESCRIPTION
## Description
We are getting this error when using the exporter. Seems like the cache size gets too big and crashes and trying to read the file.
```
Traceback (most recent call last):
  File "/usr/local/lib/python3.7/site-packages/flask/app.py", line 2073, in wsgi_app
    response = self.full_dispatch_request()
  File "/usr/local/lib/python3.7/site-packages/flask/app.py", line 1518, in full_dispatch_request
    rv = self.handle_user_exception(e)
  File "/usr/local/lib/python3.7/site-packages/flask/app.py", line 1516, in full_dispatch_request
    rv = self.dispatch_request()
  File "/usr/local/lib/python3.7/site-packages/flask/app.py", line 1502, in dispatch_request
    return self.ensure_sync(self.view_functions[rule.endpoint])(**req.view_args)
  File "/usr/local/lib/python3.7/site-packages/flask_httpauth.py", line 172, in decorated
    return self.ensure_sync(f)(*args, **kwargs)
  File "/app/exporter.py", line 101, in sentry_exporter
    REGISTRY.register(SentryCollector(sentry, ORG_SLUG, get_metric_config(), PROJECTS_SLUG))
  File "/usr/local/lib/python3.7/site-packages/prometheus_client/registry.py", line 26, in register
    names = self._get_names(collector)
  File "/usr/local/lib/python3.7/site-packages/prometheus_client/registry.py", line 66, in _get_names
    for metric in desc_func():
  File "/app/helpers/prometheus.py", line 217, in collect
    __data = self.__build_sentry_data()
  File "/app/helpers/prometheus.py", line 203, in __build_sentry_data
    data = get_cached(JSON_CACHE_FILE)
  File "/app/helpers/utils.py", line 31, in get_cached
    cache = json.load(open(filename, "r"))
  File "/usr/local/lib/python3.7/json/__init__.py", line 296, in load
    parse_constant=parse_constant, object_pairs_hook=object_pairs_hook, **kw)
  File "/usr/local/lib/python3.7/json/__init__.py", line 348, in loads
    return _default_decoder.decode(s)
  File "/usr/local/lib/python3.7/json/decoder.py", line 337, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
  File "/usr/local/lib/python3.7/json/decoder.py", line 353, in raw_decode
    obj, end = self.scan_once(s, idx)
json.decoder.JSONDecodeError: Expecting property name enclosed in double quotes: line 1 column 73811 (char 73810)
```
This is the fix:
 add a try block to ensure that the file is read correctly

## Checklist

- [ ] All tests are passing
- [ ] New tests were created to address changes in pr (and tests are passing)
- [ ] Updated README and/or documentation, if necessary

Thanks for contributing!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error handling for JSON loading to prevent crashes from corrupted cache files.
- **Chores**
	- Added necessary imports to support new functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->