### PR TITLE
Fix/double call

### DIFF
--- a/exporter.py
+++ b/exporter.py
@@ -112,7 +112,6 @@ def sentry_exporter():
 
 
 if __name__ == "__main__":
-
     if not ORG_SLUG or not AUTH_TOKEN:
         log.error("ENVs: SENTRY_AUTH_TOKEN or SENTRY_EXPORTER_ORG was not found!")
         exit(1)

--- a/exporter.py
+++ b/exporter.py
@@ -7,11 +7,11 @@ from flask import Flask
 from flask_httpauth import HTTPBasicAuth
 from flask_healthz import healthz
 from prometheus_client import make_wsgi_app
-from prometheus_client.core import REGISTRY
+from prometheus_client.core import CollectorRegistry
 from werkzeug.middleware.dispatcher import DispatcherMiddleware
 from werkzeug.security import generate_password_hash, check_password_hash
 
-from helpers.prometheus import SentryCollector, clean_registry
+from helpers.prometheus import SentryCollector
 from libs.sentry import SentryAPI
 
 # TODO - Move these settings to use Flask Ccnfiguration Handling
@@ -34,6 +34,9 @@ logging.basicConfig(
     format="[%(asctime)s] [%(process)d] [%(levelname)s] %(message)s",
     datefmt="%Y-%m-%d %H:%M:%S %z",
 )
+
+registry = CollectorRegistry()
+current_collector = None
 
 app = Flask(__name__)
 app.register_blueprint(healthz, url_prefix="/healthz")
@@ -95,11 +98,16 @@ def home():
 @app.route("/metrics/")
 @auth.login_required(optional=basic_auth_is_enabled(EXPORTER_BASIC_AUTH))
 def sentry_exporter():
+    global current_collector
     sentry = SentryAPI(BASE_URL, AUTH_TOKEN)
-    log.info("exporter: cleaning registry collectors...")
-    clean_registry()
-    REGISTRY.register(SentryCollector(sentry, ORG_SLUG, get_metric_config(), PROJECTS_SLUG))
-    exporter = DispatcherMiddleware(app.wsgi_app, {"/metrics": make_wsgi_app()})
+
+    if current_collector is not None:
+        log.info("exporter: cleaning registry collectors...")
+        registry.unregister(current_collector)
+
+    current_collector = SentryCollector(sentry, ORG_SLUG, get_metric_config(), PROJECTS_SLUG)
+    registry.register(current_collector)
+    exporter = DispatcherMiddleware(app.wsgi_app, {"/metrics": make_wsgi_app(registry=registry)})
     return exporter
 
 

--- a/helpers/prometheus.py
+++ b/helpers/prometheus.py
@@ -3,7 +3,6 @@ from datetime import datetime, timedelta
 from uuid import uuid4
 
 from prometheus_client.core import (
-    REGISTRY,
     CounterMetricFamily,
     GaugeHistogramMetricFamily,
     GaugeMetricFamily,
@@ -384,5 +383,5 @@ class SentryCollector(object):
                 project_rate_metrics.add_metric(
                     [str(project.get("slug"))], round(rate_limit_second, 6)
                 )
-
+            print(project_rate_metrics)
             yield project_rate_metrics

--- a/helpers/prometheus.py
+++ b/helpers/prometheus.py
@@ -383,5 +383,5 @@ class SentryCollector(object):
                 project_rate_metrics.add_metric(
                     [str(project.get("slug"))], round(rate_limit_second, 6)
                 )
-            print(project_rate_metrics)
+
             yield project_rate_metrics

--- a/helpers/prometheus.py
+++ b/helpers/prometheus.py
@@ -16,6 +16,7 @@ DEFAULT_CACHE_EXPIRE_TIMESTAMP = int(datetime.timestamp(datetime.now() + timedel
 
 log = logging.getLogger(__name__)
 
+
 class SentryCollector(object):
     """A simple :class:`SentryCollector <SentryCollector>` returns a list of Metric objects.
 
@@ -188,7 +189,6 @@ class SentryCollector(object):
         return data
 
     def __build_sentry_data(self):
-
         data = get_cached(JSON_CACHE_FILE)
 
         if data is False:

--- a/helpers/prometheus.py
+++ b/helpers/prometheus.py
@@ -17,16 +17,6 @@ DEFAULT_CACHE_EXPIRE_TIMESTAMP = int(datetime.timestamp(datetime.now() + timedel
 
 log = logging.getLogger(__name__)
 
-
-def clean_registry():
-    # Loop with try except to remove all default collectors
-    for _, collector in list(REGISTRY._names_to_collectors.items()):
-        try:
-            REGISTRY.unregister(collector)
-        except KeyError:
-            pass
-
-
 class SentryCollector(object):
     """A simple :class:`SentryCollector <SentryCollector>` returns a list of Metric objects.
 


### PR DESCRIPTION
## Description

close #65 

These changes are intended to create a custom registry to avoid double requests to the Sentry API made using prometheus_client.REGISTRY.

## Checklist

- [x] All tests are passing
- [ ] New tests were created to address changes in pr (and tests are passing)
- [ ] Updated README and/or documentation, if necessary



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced metric management by introducing a localized registry for better control over metric collectors.
- **Bug Fixes**
	- Improved handling of collector registration to prevent conflicts and duplication.
- **Chores**
	- Removed the `clean_registry` function to streamline the metric unregistration process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->