### PR TITLE
chore: pin black formatting config in pyproject.toml

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Black Code Formatter
         uses: lgeiger/black-action@v1.0.1
         with:
-          args: '. -l 99 -t py37 --check'
+          args: '. --check'
 
   yamllint:
     name: YAML Lint

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[tool.black]
+line-length = 99
+target-version = ["py37"]


### PR DESCRIPTION
## Summary
Small follow-up to #115. `.github/workflows/lint.yml`'s Black check runs with `-l 99 -t py37`, but nothing enforced those settings for local runs, so it's easy for a plain `black .` to silently drift from what CI expects (this happened once already in #115).

- Add `pyproject.toml` with `[tool.black]` `line-length = 99`, `target-version = ["py37"]`
- Simplify the lint workflow's Black args to `. --check` since the flags are now redundant

No code changes — `black . --check` already passes against current `master`.

## Testing
`black . --check` — clean. `pytest -v` — 14/14 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)