### PR TITLE
docs: add CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,7 +15,7 @@ helpers/prometheus.py  SentryCollector — builds Prometheus metric families
 helpers/utils.py       JSON file cache (write_cache/get_cached) + healthz probes
 ```
 
-Request flow: `GET /metrics/` in `exporter.py` builds a fresh `SentryAPI`, unregisters the previously-registered collector from the module-level `registry` (a `CollectorRegistry` instance, tracked via the `current_collector` global) if one exists, registers a new `SentryCollector`, and delegates to `prometheus_client`'s WSGI app via `DispatcherMiddleware`. All the actual work happens lazily inside `SentryCollector.collect()`, which is called by `prometheus_client` when it renders the response — not by `exporter.py` directly.
+`GET /metrics/` in `exporter.py` builds a fresh `SentryAPI`, swaps the previously-registered `SentryCollector` out of the module-level `registry` (a `CollectorRegistry` instance, tracked via the `current_collector` global) for a new one, then delegates to `prometheus_client`'s WSGI app via `DispatcherMiddleware`. All actual work happens lazily inside `SentryCollector.collect()`, invoked by `prometheus_client` when it renders the response — not by `exporter.py` directly.
 
 `SentryCollector` does not call `SentryAPI` on every scrape: it first checks `helpers.utils.get_cached()` for a live cache file and only calls the API (`__build_sentry_data_from_api`) on a cache miss/expiry. When it does hit the API, it also writes the result back to the cache file. Keep this in mind when debugging "stale metric" reports — the fix may be a cache TTL issue, not an API issue.
 
@@ -23,22 +23,24 @@ Request flow: `GET /metrics/` in `exporter.py` builds a fresh `SentryAPI`, unreg
 
 ### Metrics emitted
 
+Names and user-facing purpose are documented in README's "Metrics" section; what's worth knowing here is the underlying Prometheus type and a caveat that isn't in README:
+
 - `sentry_issues` — `GaugeHistogramMetricFamily`, issues bucketed by age (1h/24h/14d)
 - `sentry_open_issue_events` — `GaugeMetricFamily`, per-issue detail (only 1h-window issues, see below)
 - `sentry_events` — `CounterMetricFamily`, total events per project (received/rejected/blacklisted)
 - `sentry_rate_limit_events_sec` — `GaugeMetricFamily`, configured key rate limit
 
-**Known quirk:** `sentry_open_issue_events` is only ever populated from the `1h` issue bucket (`helpers/prometheus.py`, in `collect()`), regardless of which age buckets are enabled. This looks intentional (avoids emitting a huge number of per-issue label combinations) but is easy to mistake for a bug — don't "fix" it without checking with the maintainer first.
+**Known quirk:** `sentry_open_issue_events` is only ever populated from the `1h` issue bucket (`helpers/prometheus.py`, in `collect()`), regardless of which age buckets are enabled. This looks intentional (avoids high per-issue label cardinality), not a bug — don't "fix" it without checking with the maintainer first.
 
 ## Configuration
 
 Everything is env-var driven. See `README.md`'s "Project Configuration", "Metric Configuration", and "Basic Authentication" sections for the full variable reference (names, defaults, purpose) — don't duplicate that list here, keep it in sync in one place.
 
-The one gotcha worth calling out because it's easy to get wrong and isn't spelled out in README: every one of those toggle vars is compared against the **string** `"True"`, not parsed as a real boolean — `SENTRY_SCRAPE_ISSUE_METRICS=false` (lowercase) will **not** disable the feature, it has to be exactly `"True"` or anything else counts as false. Preserve this comparison style if you touch config parsing, or fix it repo-wide in one pass rather than mixing conventions.
+Gotcha not spelled out in README: every toggle var is compared against the **string** `"True"`, not parsed as a real boolean — `SENTRY_SCRAPE_ISSUE_METRICS=false` (lowercase) will **not** disable the feature, it has to be exactly `"True"` or anything else counts as false. Preserve this comparison style if you touch config parsing, or fix it repo-wide in one pass rather than mixing conventions.
 
 ## Running locally
 
-See `README.md`'s "Getting Started" section for the env vars, `python exporter.py`, and `docker-compose up -d` flows. The one thing worth adding here: the Dockerfile's actual `CMD` (and what you should run to match prod behavior locally) is gunicorn, not the Flask dev server:
+See `README.md`'s "Getting Started" section for the env vars, `python exporter.py`, and `docker-compose up -d` flows. Locally this maps to gunicorn, not the Flask dev server, to match prod (matches the Dockerfile `CMD`):
 
 ```sh
 gunicorn -w 4 -b 0.0.0.0:9790 exporter:app
@@ -46,7 +48,7 @@ gunicorn -w 4 -b 0.0.0.0:9790 exporter:app
 
 ## Testing
 
-**There is currently no `tests/` directory or test tooling on `master`.** CI (`.github/workflows/lint.yml`) only lints Python (Black), and only runs lint — not tests:
+**There is currently no `tests/` directory or test tooling on `master`.** CI (`.github/workflows/lint.yml`) only runs Black lint — no tests:
 
 ```sh
 black -l 99 -t py37 --check .
@@ -55,7 +57,7 @@ black -l 99 -t py37 --check .
 If you add tests:
 
 - Don't bolt pytest onto the existing single-stage `python:3.7-slim` Dockerfile — give the test stage its own build stage and its own Python version (whatever `requirements-dev.txt` actually needs), independent of the runtime stage's 3.7 pin.
-- Run Black locally before pushing rather than relying on CI alone — install whatever version is pinned by the `lgeiger/black-action` step in `.github/workflows/lint.yml`, then `black -l 99 -t py37 --check .`.
+- Run the same check as CI locally before pushing rather than relying on CI alone — install whatever Black version is pinned by the `lgeiger/black-action` step in `.github/workflows/lint.yml`.
 
 ## Sentry API surface (`libs/sentry.py`)
 
@@ -63,11 +65,11 @@ If you add tests:
 
 All GET requests share one private `__get()` with `@retry` (from the `retry` package) on `requests.exceptions.HTTPError`, configured via the `SENTRY_RETRY_*` env vars. `__post` is a stub (`raise NotImplementedError`) — this class is read-only by design; don't add mutating calls without discussing the retry/idempotency implications first.
 
-Sentry rate-limits to ~3 req/s, and the exporter has no concurrency (see "Known limitations" below) — for orgs with many projects/environments this combination can be slow enough to blow past Prometheus's scrape timeout.
+Sentry rate-limits to ~3 req/s (see README's Limitations section), and the exporter has no concurrency (see "Known limitations" below) — for orgs with many projects/environments this combination can be slow enough to blow past Prometheus's scrape timeout.
 
 ## Code style
 
-- Follow existing formatting: Black with `-l 99 -t py37` (100 columns is wrong here — it's 99). Run Black before committing; CI will fail otherwise.
+- Follow existing formatting: Black, same invocation as CI (see Testing above) — 99 columns, not 100. Run it before committing; CI will fail otherwise.
 - `.format()`-style string formatting is used throughout (not f-strings) — match it in new code for consistency, this repo still targets Python 3.7.
 - Logging uses the stdlib `logging` module with module-level `log = logging.getLogger(__name__)`; log levels follow a `metadata: ...` / `collector: ...` / `cache: ...` / `auth: ...` prefix convention in message strings — keep using a prefix that matches the surrounding code when adding new log lines.
 - Docstrings are Google-style (`Args:` / `Returns:` / `Raises:`) — match this in `libs/sentry.py` when adding methods there.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,7 +15,7 @@ helpers/prometheus.py  SentryCollector — builds Prometheus metric families
 helpers/utils.py       JSON file cache (write_cache/get_cached) + healthz probes
 ```
 
-Request flow: `GET /metrics/` in `exporter.py` builds a fresh `SentryAPI`, clears the Prometheus `REGISTRY` (`clean_registry()`), registers a new `SentryCollector`, and delegates to `prometheus_client`'s WSGI app via `DispatcherMiddleware`. All the actual work happens lazily inside `SentryCollector.collect()`, which is called by `prometheus_client` when it renders the response — not by `exporter.py` directly.
+Request flow: `GET /metrics/` in `exporter.py` builds a fresh `SentryAPI`, unregisters the previously-registered collector from the module-level `registry` (a `CollectorRegistry` instance, tracked via the `current_collector` global) if one exists, registers a new `SentryCollector`, and delegates to `prometheus_client`'s WSGI app via `DispatcherMiddleware`. All the actual work happens lazily inside `SentryCollector.collect()`, which is called by `prometheus_client` when it renders the response — not by `exporter.py` directly.
 
 `SentryCollector` does not call `SentryAPI` on every scrape: it first checks `helpers.utils.get_cached()` for a live cache file and only calls the API (`__build_sentry_data_from_api`) on a cache miss/expiry. When it does hit the API, it also writes the result back to the cache file. Keep this in mind when debugging "stale metric" reports — the fix may be a cache TTL issue, not an API issue.
 
@@ -32,47 +32,30 @@ Request flow: `GET /metrics/` in `exporter.py` builds a fresh `SentryAPI`, clear
 
 ## Configuration
 
-Everything is env-var driven (see `exporter.py` top and `README.md`). Notable ones:
+Everything is env-var driven. See `README.md`'s "Project Configuration", "Metric Configuration", and "Basic Authentication" sections for the full variable reference (names, defaults, purpose) — don't duplicate that list here, keep it in sync in one place.
 
-- `SENTRY_BASE_URL` (default `https://sentry.io/api/0/`), `SENTRY_AUTH_TOKEN`, `SENTRY_EXPORTER_ORG` (required)
-- `SENTRY_EXPORTER_PROJECTS` — comma-separated slugs; omit to auto-discover all projects
-- `SENTRY_SCRAPE_ISSUE_METRICS` / `SENTRY_SCRAPE_EVENT_METRICS` / `SENTRY_SCRAPE_RATE_LIMIT_METRICS`
-- `SENTRY_ISSUES_1H` / `SENTRY_ISSUES_24H` / `SENTRY_ISSUES_14D`
-- `SENTRY_EXPORTER_BASIC_AUTH(_USER|_PASS)`
-- `SENTRY_RETRY_TRIES` / `_DELAY` / `_MAX_DELAY` / `_BACKOFF` / `_JITTER` (used by `libs/sentry.py`'s `@retry`)
-
-All of these are compared against the **string** `"True"`, not parsed as booleans — `SENTRY_SCRAPE_ISSUE_METRICS=false` (lowercase) will NOT disable the feature. Preserve this comparison style if you touch config parsing, or fix it repo-wide in one pass rather than mixing conventions.
+The one gotcha worth calling out because it's easy to get wrong and isn't spelled out in README: every one of those toggle vars is compared against the **string** `"True"`, not parsed as a real boolean — `SENTRY_SCRAPE_ISSUE_METRICS=false` (lowercase) will **not** disable the feature, it has to be exactly `"True"` or anything else counts as false. Preserve this comparison style if you touch config parsing, or fix it repo-wide in one pass rather than mixing conventions.
 
 ## Running locally
 
-```sh
-export SENTRY_BASE_URL="https://sentry.io/api/0/"
-export SENTRY_AUTH_TOKEN="[token]"
-export SENTRY_EXPORTER_ORG="[org-slug]"
-python exporter.py            # dev server, or:
-gunicorn -w 4 -b 0.0.0.0:9790 exporter:app   # prod-like, matches Dockerfile CMD
-```
+See `README.md`'s "Getting Started" section for the env vars, `python exporter.py`, and `docker-compose up -d` flows. The one thing worth adding here: the Dockerfile's actual `CMD` (and what you should run to match prod behavior locally) is gunicorn, not the Flask dev server:
 
 ```sh
-docker-compose up -d          # brings up prometheus + grafana + this exporter
+gunicorn -w 4 -b 0.0.0.0:9790 exporter:app
 ```
-
-`docker-compose.yaml` expects a local `.env` file (not committed) with the vars above.
 
 ## Testing
 
-**There is currently no `tests/` directory or test tooling on `master`.** CI (`.github/workflows/lint.yml`) only lints Python, and only runs lint — not tests:
-
-- `black -l 99 -t py37 --check .` (Black, line length 99, Python 3.7 target)
-
-If you add tests, match the pattern already prototyped on the `sentry-api-audit-plan` worktree/branch: `pytest` via `requirements-dev.txt`, a `tests/` package, and a dedicated `test` build stage in the Dockerfile (`FROM python:3.8-slim AS test`, installs both requirement files, `CMD ["pytest"]`) — do not just bolt pytest onto the existing `python:3.7-slim` runtime image. Note **3.7 vs 3.8**: the runtime image is pinned to `python:3.7-slim` while newer dev/test dependencies may require 3.8+; if you touch the Dockerfile, keep the runtime and test stages on the Python versions that actually satisfy each requirements file — don't assume they match.
-
-Before merging, actually run Black locally rather than relying on CI alone:
+**There is currently no `tests/` directory or test tooling on `master`.** CI (`.github/workflows/lint.yml`) only lints Python (Black), and only runs lint — not tests:
 
 ```sh
-pip install black==<version pinned by lgeiger/black-action@v1.0.1>
 black -l 99 -t py37 --check .
 ```
+
+If you add tests:
+
+- Don't bolt pytest onto the existing single-stage `python:3.7-slim` Dockerfile — give the test stage its own build stage and its own Python version (whatever `requirements-dev.txt` actually needs), independent of the runtime stage's 3.7 pin.
+- Run Black locally before pushing rather than relying on CI alone — install whatever version is pinned by the `lgeiger/black-action` step in `.github/workflows/lint.yml`, then `black -l 99 -t py37 --check .`.
 
 ## Sentry API surface (`libs/sentry.py`)
 
@@ -80,7 +63,7 @@ black -l 99 -t py37 --check .
 
 All GET requests share one private `__get()` with `@retry` (from the `retry` package) on `requests.exceptions.HTTPError`, configured via the `SENTRY_RETRY_*` env vars. `__post` is a stub (`raise NotImplementedError`) — this class is read-only by design; don't add mutating calls without discussing the retry/idempotency implications first.
 
-Sentry rate-limits to ~3 req/s. The exporter is **serial** (no concurrency) — for orgs with many projects/environments this can be slow enough to blow past Prometheus's scrape timeout. If you're asked to speed this up, prefer batching/async at the `SentryCollector` level over touching the retry logic.
+Sentry rate-limits to ~3 req/s, and the exporter has no concurrency (see "Known limitations" below) — for orgs with many projects/environments this combination can be slow enough to blow past Prometheus's scrape timeout.
 
 ## Code style
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,10 +90,10 @@ vars above.
 ## Testing
 
 **There is currently no `tests/` directory or test tooling on `master`.**
-CI (`.github/workflows/`) only runs lint, not tests:
+CI (`.github/workflows/lint.yml`) only lints Python, and only runs lint —
+not tests:
 
 - `black -l 99 -t py37 --check .` (Black, line length 99, Python 3.7 target)
-- `yamllint` (`line-length: 99`, `truthy` rule disabled, indentation `consistent`)
 
 If you add tests, match the pattern already prototyped on the
 `sentry-api-audit-plan` worktree/branch: `pytest` via `requirements-dev.txt`,
@@ -106,8 +106,7 @@ touch the Dockerfile, keep the runtime and test stages on the Python
 versions that actually satisfy each requirements file — don't assume they
 match.
 
-Before merging, actually run black/yamllint locally rather than relying on
-CI alone:
+Before merging, actually run Black locally rather than relying on CI alone:
 
 ```sh
 pip install black==<version pinned by lgeiger/black-action@v1.0.1>

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,163 @@
+# CLAUDE.md
+
+Guidance for Claude Code (and other agents) working in this repository.
+
+## What this is
+
+A small Flask app that polls the Sentry Web API and re-exposes org/project
+metrics (open issues, event counts, key rate limits) in Prometheus
+exposition format. It's a single-purpose exporter, not a service with a
+database — all state is either fetched live from Sentry or held in a
+2-minute JSON file cache at `/tmp/sentry-prometheus-exporter-cache.json`.
+
+## Architecture
+
+```
+exporter.py            Flask app: routes, env-var config, Basic Auth, healthz
+libs/sentry.py         SentryAPI — thin wrapper around Sentry's REST API
+helpers/prometheus.py  SentryCollector — builds Prometheus metric families
+helpers/utils.py       JSON file cache (write_cache/get_cached) + healthz probes
+```
+
+Request flow: `GET /metrics/` in `exporter.py` builds a fresh `SentryAPI`,
+clears the Prometheus `REGISTRY` (`clean_registry()`), registers a new
+`SentryCollector`, and delegates to `prometheus_client`'s WSGI app via
+`DispatcherMiddleware`. All the actual work happens lazily inside
+`SentryCollector.collect()`, which is called by `prometheus_client` when it
+renders the response — not by `exporter.py` directly.
+
+`SentryCollector` does not call `SentryAPI` on every scrape: it first checks
+`helpers.utils.get_cached()` for a live cache file and only calls the API
+(`__build_sentry_data_from_api`) on a cache miss/expiry. When it does hit
+the API, it also writes the result back to the cache file. Keep this in mind
+when debugging "stale metric" reports — the fix may be a cache TTL issue,
+not an API issue.
+
+`SentryCollector.__init__` takes `metric_scraping_config` as a **positional
+list** of 6 string booleans (`"True"`/`"False"`, not real Python bools):
+`[issue_metrics, events_metrics, rate_limit_metrics, get_1h, get_24h, get_14d]`,
+built by `exporter.get_metric_config()`. If you add a new scrape toggle,
+you must update the list in both places, in order — there's no named-arg
+safety net here.
+
+### Metrics emitted
+
+- `sentry_issues` — `GaugeHistogramMetricFamily`, issues bucketed by age (1h/24h/14d)
+- `sentry_open_issue_events` — `GaugeMetricFamily`, per-issue detail (only 1h-window issues, see below)
+- `sentry_events` — `CounterMetricFamily`, total events per project (received/rejected/blacklisted)
+- `sentry_rate_limit_events_sec` — `GaugeMetricFamily`, configured key rate limit
+
+**Known quirk:** `sentry_open_issue_events` is only ever populated from the
+`1h` issue bucket (`helpers/prometheus.py`, in `collect()`), regardless of
+which age buckets are enabled. This looks intentional (avoids emitting a
+huge number of per-issue label combinations) but is easy to mistake for a
+bug — don't "fix" it without checking with the maintainer first.
+
+## Configuration
+
+Everything is env-var driven (see `exporter.py` top and `README.md`).
+Notable ones:
+
+- `SENTRY_BASE_URL` (default `https://sentry.io/api/0/`), `SENTRY_AUTH_TOKEN`, `SENTRY_EXPORTER_ORG` (required)
+- `SENTRY_EXPORTER_PROJECTS` — comma-separated slugs; omit to auto-discover all projects
+- `SENTRY_SCRAPE_ISSUE_METRICS` / `SENTRY_SCRAPE_EVENT_METRICS` / `SENTRY_SCRAPE_RATE_LIMIT_METRICS`
+- `SENTRY_ISSUES_1H` / `SENTRY_ISSUES_24H` / `SENTRY_ISSUES_14D`
+- `SENTRY_EXPORTER_BASIC_AUTH(_USER|_PASS)`
+- `SENTRY_RETRY_TRIES` / `_DELAY` / `_MAX_DELAY` / `_BACKOFF` / `_JITTER` (used by `libs/sentry.py`'s `@retry`)
+
+All of these are compared against the **string** `"True"`, not parsed as
+booleans — `SENTRY_SCRAPE_ISSUE_METRICS=false` (lowercase) will NOT disable
+the feature. Preserve this comparison style if you touch config parsing, or
+fix it repo-wide in one pass rather than mixing conventions.
+
+## Running locally
+
+```sh
+export SENTRY_BASE_URL="https://sentry.io/api/0/"
+export SENTRY_AUTH_TOKEN="[token]"
+export SENTRY_EXPORTER_ORG="[org-slug]"
+python exporter.py            # dev server, or:
+gunicorn -w 4 -b 0.0.0.0:9790 exporter:app   # prod-like, matches Dockerfile CMD
+```
+
+```sh
+docker-compose up -d          # brings up prometheus + grafana + this exporter
+```
+
+`docker-compose.yaml` expects a local `.env` file (not committed) with the
+vars above.
+
+## Testing
+
+**There is currently no `tests/` directory or test tooling on `master`.**
+CI (`.github/workflows/`) only runs lint, not tests:
+
+- `black -l 99 -t py37 --check .` (Black, line length 99, Python 3.7 target)
+- `yamllint` (`line-length: 99`, `truthy` rule disabled, indentation `consistent`)
+
+If you add tests, match the pattern already prototyped on the
+`sentry-api-audit-plan` worktree/branch: `pytest` via `requirements-dev.txt`,
+a `tests/` package, and a dedicated `test` build stage in the Dockerfile
+(`FROM python:3.8-slim AS test`, installs both requirement files, `CMD
+["pytest"]`) — do not just bolt pytest onto the existing `python:3.7-slim`
+runtime image. Note **3.7 vs 3.8**: the runtime image is pinned to
+`python:3.7-slim` while newer dev/test dependencies may require 3.8+; if you
+touch the Dockerfile, keep the runtime and test stages on the Python
+versions that actually satisfy each requirements file — don't assume they
+match.
+
+Before merging, actually run black/yamllint locally rather than relying on
+CI alone:
+
+```sh
+pip install black==<version pinned by lgeiger/black-action@v1.0.1>
+black -l 99 -t py37 --check .
+```
+
+## Sentry API surface (`libs/sentry.py`)
+
+`SentryAPI` methods each hand-pick which fields to keep from Sentry's JSON
+response (e.g. `get_org` returns only `id/slug/name/status/platform`) — if
+a new metric needs a field that isn't already being kept, you'll need to
+add it to the relevant method's dict, not just read it off the raw
+response.
+
+All GET requests share one private `__get()` with `@retry` (from the
+`retry` package) on `requests.exceptions.HTTPError`, configured via the
+`SENTRY_RETRY_*` env vars. `__post` is a stub (`raise NotImplementedError`)
+— this class is read-only by design; don't add mutating calls without
+discussing the retry/idempotency implications first.
+
+Sentry rate-limits to ~3 req/s. The exporter is **serial** (no
+concurrency) — for orgs with many projects/environments this can be slow
+enough to blow past Prometheus's scrape timeout. If you're asked to speed
+this up, prefer batching/async at the `SentryCollector` level over touching
+the retry logic.
+
+## Code style
+
+- Follow existing formatting: Black with `-l 99 -t py37` (100 columns is
+  wrong here — it's 99). Run Black before committing; CI will fail
+  otherwise.
+- `.format()`-style string formatting is used throughout (not f-strings) —
+  match it in new code for consistency, this repo still targets Python 3.7.
+- Logging uses the stdlib `logging` module with module-level
+  `log = logging.getLogger(__name__)`; log levels follow a `metadata: ...`
+  / `collector: ...` / `cache: ...` / `auth: ...` prefix convention in
+  message strings — keep using a prefix that matches the surrounding code
+  when adding new log lines.
+- Docstrings are Google-style (`Args:` / `Returns:` / `Raises:`) — match
+  this in `libs/sentry.py` when adding methods there.
+
+## Known limitations (don't "fix" silently — flag first)
+
+- No horizontal scaling / concurrency story; a single slow scrape blocks
+  the whole exporter (Flask dev server / gunicorn workers each block on
+  their own request).
+- The JSON file cache is a single shared path
+  (`/tmp/sentry-prometheus-exporter-cache.json`) with no locking — fine
+  for a single-process deployment, unsafe if you ever run multiple
+  gunicorn workers scraping independently (each worker keeps re-caching).
+- `readiness()` in `helpers/utils.py` only instantiates `SentryAPI`; it
+  never actually calls Sentry, so `/healthz/ready` can report healthy even
+  when the auth token or base URL is wrong.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,11 +4,7 @@ Guidance for Claude Code (and other agents) working in this repository.
 
 ## What this is
 
-A small Flask app that polls the Sentry Web API and re-exposes org/project
-metrics (open issues, event counts, key rate limits) in Prometheus
-exposition format. It's a single-purpose exporter, not a service with a
-database — all state is either fetched live from Sentry or held in a
-2-minute JSON file cache at `/tmp/sentry-prometheus-exporter-cache.json`.
+A small Flask app that polls the Sentry Web API and re-exposes org/project metrics (open issues, event counts, key rate limits) in Prometheus exposition format. It's a single-purpose exporter, not a service with a database — all state is either fetched live from Sentry or held in a 2-minute JSON file cache at `/tmp/sentry-prometheus-exporter-cache.json`.
 
 ## Architecture
 
@@ -19,26 +15,11 @@ helpers/prometheus.py  SentryCollector — builds Prometheus metric families
 helpers/utils.py       JSON file cache (write_cache/get_cached) + healthz probes
 ```
 
-Request flow: `GET /metrics/` in `exporter.py` builds a fresh `SentryAPI`,
-clears the Prometheus `REGISTRY` (`clean_registry()`), registers a new
-`SentryCollector`, and delegates to `prometheus_client`'s WSGI app via
-`DispatcherMiddleware`. All the actual work happens lazily inside
-`SentryCollector.collect()`, which is called by `prometheus_client` when it
-renders the response — not by `exporter.py` directly.
+Request flow: `GET /metrics/` in `exporter.py` builds a fresh `SentryAPI`, clears the Prometheus `REGISTRY` (`clean_registry()`), registers a new `SentryCollector`, and delegates to `prometheus_client`'s WSGI app via `DispatcherMiddleware`. All the actual work happens lazily inside `SentryCollector.collect()`, which is called by `prometheus_client` when it renders the response — not by `exporter.py` directly.
 
-`SentryCollector` does not call `SentryAPI` on every scrape: it first checks
-`helpers.utils.get_cached()` for a live cache file and only calls the API
-(`__build_sentry_data_from_api`) on a cache miss/expiry. When it does hit
-the API, it also writes the result back to the cache file. Keep this in mind
-when debugging "stale metric" reports — the fix may be a cache TTL issue,
-not an API issue.
+`SentryCollector` does not call `SentryAPI` on every scrape: it first checks `helpers.utils.get_cached()` for a live cache file and only calls the API (`__build_sentry_data_from_api`) on a cache miss/expiry. When it does hit the API, it also writes the result back to the cache file. Keep this in mind when debugging "stale metric" reports — the fix may be a cache TTL issue, not an API issue.
 
-`SentryCollector.__init__` takes `metric_scraping_config` as a **positional
-list** of 6 string booleans (`"True"`/`"False"`, not real Python bools):
-`[issue_metrics, events_metrics, rate_limit_metrics, get_1h, get_24h, get_14d]`,
-built by `exporter.get_metric_config()`. If you add a new scrape toggle,
-you must update the list in both places, in order — there's no named-arg
-safety net here.
+`SentryCollector.__init__` takes `metric_scraping_config` as a **positional list** of 6 string booleans (`"True"`/`"False"`, not real Python bools): `[issue_metrics, events_metrics, rate_limit_metrics, get_1h, get_24h, get_14d]`, built by `exporter.get_metric_config()`. If you add a new scrape toggle, you must update the list in both places, in order — there's no named-arg safety net here.
 
 ### Metrics emitted
 
@@ -47,16 +28,11 @@ safety net here.
 - `sentry_events` — `CounterMetricFamily`, total events per project (received/rejected/blacklisted)
 - `sentry_rate_limit_events_sec` — `GaugeMetricFamily`, configured key rate limit
 
-**Known quirk:** `sentry_open_issue_events` is only ever populated from the
-`1h` issue bucket (`helpers/prometheus.py`, in `collect()`), regardless of
-which age buckets are enabled. This looks intentional (avoids emitting a
-huge number of per-issue label combinations) but is easy to mistake for a
-bug — don't "fix" it without checking with the maintainer first.
+**Known quirk:** `sentry_open_issue_events` is only ever populated from the `1h` issue bucket (`helpers/prometheus.py`, in `collect()`), regardless of which age buckets are enabled. This looks intentional (avoids emitting a huge number of per-issue label combinations) but is easy to mistake for a bug — don't "fix" it without checking with the maintainer first.
 
 ## Configuration
 
-Everything is env-var driven (see `exporter.py` top and `README.md`).
-Notable ones:
+Everything is env-var driven (see `exporter.py` top and `README.md`). Notable ones:
 
 - `SENTRY_BASE_URL` (default `https://sentry.io/api/0/`), `SENTRY_AUTH_TOKEN`, `SENTRY_EXPORTER_ORG` (required)
 - `SENTRY_EXPORTER_PROJECTS` — comma-separated slugs; omit to auto-discover all projects
@@ -65,10 +41,7 @@ Notable ones:
 - `SENTRY_EXPORTER_BASIC_AUTH(_USER|_PASS)`
 - `SENTRY_RETRY_TRIES` / `_DELAY` / `_MAX_DELAY` / `_BACKOFF` / `_JITTER` (used by `libs/sentry.py`'s `@retry`)
 
-All of these are compared against the **string** `"True"`, not parsed as
-booleans — `SENTRY_SCRAPE_ISSUE_METRICS=false` (lowercase) will NOT disable
-the feature. Preserve this comparison style if you touch config parsing, or
-fix it repo-wide in one pass rather than mixing conventions.
+All of these are compared against the **string** `"True"`, not parsed as booleans — `SENTRY_SCRAPE_ISSUE_METRICS=false` (lowercase) will NOT disable the feature. Preserve this comparison style if you touch config parsing, or fix it repo-wide in one pass rather than mixing conventions.
 
 ## Running locally
 
@@ -84,27 +57,15 @@ gunicorn -w 4 -b 0.0.0.0:9790 exporter:app   # prod-like, matches Dockerfile CMD
 docker-compose up -d          # brings up prometheus + grafana + this exporter
 ```
 
-`docker-compose.yaml` expects a local `.env` file (not committed) with the
-vars above.
+`docker-compose.yaml` expects a local `.env` file (not committed) with the vars above.
 
 ## Testing
 
-**There is currently no `tests/` directory or test tooling on `master`.**
-CI (`.github/workflows/lint.yml`) only lints Python, and only runs lint —
-not tests:
+**There is currently no `tests/` directory or test tooling on `master`.** CI (`.github/workflows/lint.yml`) only lints Python, and only runs lint — not tests:
 
 - `black -l 99 -t py37 --check .` (Black, line length 99, Python 3.7 target)
 
-If you add tests, match the pattern already prototyped on the
-`sentry-api-audit-plan` worktree/branch: `pytest` via `requirements-dev.txt`,
-a `tests/` package, and a dedicated `test` build stage in the Dockerfile
-(`FROM python:3.8-slim AS test`, installs both requirement files, `CMD
-["pytest"]`) — do not just bolt pytest onto the existing `python:3.7-slim`
-runtime image. Note **3.7 vs 3.8**: the runtime image is pinned to
-`python:3.7-slim` while newer dev/test dependencies may require 3.8+; if you
-touch the Dockerfile, keep the runtime and test stages on the Python
-versions that actually satisfy each requirements file — don't assume they
-match.
+If you add tests, match the pattern already prototyped on the `sentry-api-audit-plan` worktree/branch: `pytest` via `requirements-dev.txt`, a `tests/` package, and a dedicated `test` build stage in the Dockerfile (`FROM python:3.8-slim AS test`, installs both requirement files, `CMD ["pytest"]`) — do not just bolt pytest onto the existing `python:3.7-slim` runtime image. Note **3.7 vs 3.8**: the runtime image is pinned to `python:3.7-slim` while newer dev/test dependencies may require 3.8+; if you touch the Dockerfile, keep the runtime and test stages on the Python versions that actually satisfy each requirements file — don't assume they match.
 
 Before merging, actually run Black locally rather than relying on CI alone:
 
@@ -115,48 +76,21 @@ black -l 99 -t py37 --check .
 
 ## Sentry API surface (`libs/sentry.py`)
 
-`SentryAPI` methods each hand-pick which fields to keep from Sentry's JSON
-response (e.g. `get_org` returns only `id/slug/name/status/platform`) — if
-a new metric needs a field that isn't already being kept, you'll need to
-add it to the relevant method's dict, not just read it off the raw
-response.
+`SentryAPI` methods each hand-pick which fields to keep from Sentry's JSON response (e.g. `get_org` returns only `id/slug/name/status/platform`) — if a new metric needs a field that isn't already being kept, you'll need to add it to the relevant method's dict, not just read it off the raw response.
 
-All GET requests share one private `__get()` with `@retry` (from the
-`retry` package) on `requests.exceptions.HTTPError`, configured via the
-`SENTRY_RETRY_*` env vars. `__post` is a stub (`raise NotImplementedError`)
-— this class is read-only by design; don't add mutating calls without
-discussing the retry/idempotency implications first.
+All GET requests share one private `__get()` with `@retry` (from the `retry` package) on `requests.exceptions.HTTPError`, configured via the `SENTRY_RETRY_*` env vars. `__post` is a stub (`raise NotImplementedError`) — this class is read-only by design; don't add mutating calls without discussing the retry/idempotency implications first.
 
-Sentry rate-limits to ~3 req/s. The exporter is **serial** (no
-concurrency) — for orgs with many projects/environments this can be slow
-enough to blow past Prometheus's scrape timeout. If you're asked to speed
-this up, prefer batching/async at the `SentryCollector` level over touching
-the retry logic.
+Sentry rate-limits to ~3 req/s. The exporter is **serial** (no concurrency) — for orgs with many projects/environments this can be slow enough to blow past Prometheus's scrape timeout. If you're asked to speed this up, prefer batching/async at the `SentryCollector` level over touching the retry logic.
 
 ## Code style
 
-- Follow existing formatting: Black with `-l 99 -t py37` (100 columns is
-  wrong here — it's 99). Run Black before committing; CI will fail
-  otherwise.
-- `.format()`-style string formatting is used throughout (not f-strings) —
-  match it in new code for consistency, this repo still targets Python 3.7.
-- Logging uses the stdlib `logging` module with module-level
-  `log = logging.getLogger(__name__)`; log levels follow a `metadata: ...`
-  / `collector: ...` / `cache: ...` / `auth: ...` prefix convention in
-  message strings — keep using a prefix that matches the surrounding code
-  when adding new log lines.
-- Docstrings are Google-style (`Args:` / `Returns:` / `Raises:`) — match
-  this in `libs/sentry.py` when adding methods there.
+- Follow existing formatting: Black with `-l 99 -t py37` (100 columns is wrong here — it's 99). Run Black before committing; CI will fail otherwise.
+- `.format()`-style string formatting is used throughout (not f-strings) — match it in new code for consistency, this repo still targets Python 3.7.
+- Logging uses the stdlib `logging` module with module-level `log = logging.getLogger(__name__)`; log levels follow a `metadata: ...` / `collector: ...` / `cache: ...` / `auth: ...` prefix convention in message strings — keep using a prefix that matches the surrounding code when adding new log lines.
+- Docstrings are Google-style (`Args:` / `Returns:` / `Raises:`) — match this in `libs/sentry.py` when adding methods there.
 
 ## Known limitations (don't "fix" silently — flag first)
 
-- No horizontal scaling / concurrency story; a single slow scrape blocks
-  the whole exporter (Flask dev server / gunicorn workers each block on
-  their own request).
-- The JSON file cache is a single shared path
-  (`/tmp/sentry-prometheus-exporter-cache.json`) with no locking — fine
-  for a single-process deployment, unsafe if you ever run multiple
-  gunicorn workers scraping independently (each worker keeps re-caching).
-- `readiness()` in `helpers/utils.py` only instantiates `SentryAPI`; it
-  never actually calls Sentry, so `/healthz/ready` can report healthy even
-  when the auth token or base URL is wrong.
+- No horizontal scaling / concurrency story; a single slow scrape blocks the whole exporter (Flask dev server / gunicorn workers each block on their own request).
+- The JSON file cache is a single shared path (`/tmp/sentry-prometheus-exporter-cache.json`) with no locking — fine for a single-process deployment, unsafe if you ever run multiple gunicorn workers scraping independently (each worker keeps re-caching).
+- `readiness()` in `helpers/utils.py` only instantiates `SentryAPI`; it never actually calls Sentry, so `/healthz/ready` can report healthy even when the auth token or base URL is wrong.


### PR DESCRIPTION
## Summary

Adds a `CLAUDE.md` for agents (and human contributors) working in this repo: architecture overview, the metric-scraping config contract, env-var gotchas, testing status, and known limitations.

- Documents the `exporter.py` → `SentryCollector` → `SentryAPI` request flow, including the `CollectorRegistry`/`current_collector` registration pattern and the 2-minute JSON file cache.
- Flags the `metric_scraping_config` positional-list contract and the `sentry_open_issue_events` "1h-bucket only" quirk so they aren't mistaken for bugs later.
- Cross-references `README.md` for env-var reference and run instructions instead of duplicating them, calling out only the one gotcha not already in README (toggle vars compare against the literal string `"True"`).
- Notes there's currently no `tests/` directory/test tooling on `master`, and that CI only runs Black lint.
- Lists known limitations (no concurrency, unlocked shared cache file, no-op readiness probe) as things to flag before "fixing" silently.

Went through two `/simplify` passes (reuse/simplification/efficiency/altitude) checked against the live source and README, including a correction after discovering this branch's base (`origin/master`) already had the registry-handling refactor from #115.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>